### PR TITLE
auto detect base url from location of  file

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -70,7 +70,7 @@ function getFrameText(frames, currentTime) {
 
 
 function initializeVideoMap(data) {
-    const baseUrl = data.base_url || '';
+    const baseUrl = DATA_URL.split("videos.geojson")[0];
 
     // This is a very weird variable, I apologize. The problem is that we have this weird hack
     // on video seeked event where we need to play the video and pause it immediately, to 


### PR DESCRIPTION
Closes #2

This assumes that all the `.webm` files are accessible in the same url as the `videos.geojson` file. Which is fin as a convention for now I think. Certainly works for S3 links.