### PR TITLE
Stac2video improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 node_modules
 yarn-error.log
+__pycache__

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Options:
                     14D. This will be passed to the `resample` function on the
                     time dimension from xarray. See https://docs.xarray.dev/en
                     /stable/generated/xarray.DataArray.resample.html
+  --up INTEGER      Use higher zoom level to determine resolution of output
+                    videos. The default resolution is 256x256 pixels. Up works
+                    as multiplier. For instance, for up=1, the resolution of
+                    the video will be 512x512 pixels, and up=2 it will be
+                    1024x1024 px
+  --images          Output each frame as png image as well
+  --keep-mp4        Keep intermediary mp4 files
   --help            Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,41 @@ To run, use your favourite method to serve a local web-server in this folder. Wi
 Then, go to http://localhost:9000 in your browser.
 
 ### Video creation
+The `stac2video` command-line utility can be used to prepare videos from Sentinel-2
+imagery. The utility will create videos from imagery over a time range at fixed
+time intervals, as specified by the user. Every frame of the videos is a
+composite image. The latest non-cloudy pixel is used as compositing criteria,
+using the cloud and cloud shadow masks from the Sentinel-2 SCL layer.
 
-The `stac2video.py` utility can be used to prepare videos from Sentinel-2 imagery. The utility also creates a `videos.geojson` file, which will be used by the frontend to place the videos on the map.
+The key input the user needs to specify is location, a date range, and the
+number of tiles to create at a specified zoom level around the center point.
+The output of the script will be written to a local folder that is also 
+specified by the user.
 
-The utility will create videos from bi-weekly composites. Each frame in the video will be imagery from a two-weeks interval, where the least cloudy pixel is selected for the imagery from each two weeks.
+In addition to the video files, the utility also creates a valid geojson file
+called `videos.geojson`. This file will be used by the frontend application
+to place the video tiles on the map and to track some metadata about the
+imagery used for the videomap creation.
 
-The key input the user needs to specify is location, a date range, and the number of tiles to create at a specified zoom level. The output of the script will be written to a local folder that is also specified by the user.
-
-The following shows a list of the input parameters
+To install the command line utility, checkout the repo and then use pip
+to install the script into your python environment.
 
 ```
->>> stac2video.py --help
+pip install -e .
+```
+
+The following example will create a videomap with 5x3 tiles at zoom level 12
+with monthly image composites.
+
+
+```
+stac2video --dst=/path/to/existing/folder/videos --coordx=-9.15032 --coordy=38.72595 --start=2023-01-01 --end=2023-05-01 --zoom=12 --width=5 --height=3 --interval=1M
+```
+
+Use the help function to obtain a full list of the input parameters
+
+```
+>>> stac2video --help
 Usage: stac2video.py [OPTIONS]
 
 Options:
@@ -68,23 +92,10 @@ Options:
                     videos. The default resolution is 256x256 pixels. Up works
                     as multiplier. For instance, for up=1, the resolution of
                     the video will be 512x512 pixels, and up=2 it will be
-                    1024x1024 px
+                    1024x1024 pixels
   --images          Output each frame as png image as well
   --keep-mp4        Keep intermediary mp4 files
   --help            Show this message and exit.
-```
-
-And one example is the following:
-
-
-```
-./stac2video.py --dst=/path/to/exiting/folder/videos --coordx=-9.15032 --coordy=38.72595 --start=2023-01-01 --end=2023-05-01 --zoom=12 --width=5 --height=3
-```
-
-The required python packages can be installed using the requirements file
-
-```
-pip install -r requirements.txt
 ```
 
 ### Deploying the data

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,7 +1,0 @@
-opencv-python 
-morecantile
-stackstac
-pystac_client
-click
-ffmpeg-python
-pillow

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -4,3 +4,4 @@ stackstac
 pystac_client
 click
 ffmpeg-python
+pillow

--- a/py/stac2video.py
+++ b/py/stac2video.py
@@ -12,6 +12,7 @@ import numpy
 import pystac_client
 import stackstac
 import xarray
+from PIL import Image
 from rasterio.enums import Resampling
 
 # 0 NO_DATA
@@ -28,15 +29,21 @@ from rasterio.enums import Resampling
 # 11 SNOW
 CLOUDY_OR_NODATA = (0, 3, 8, 9, 10)
 
-catalog = pystac_client.Client.open("https://earth-search.aws.element84.com/v0/")
+catalog = pystac_client.Client.open("https://earth-search.aws.element84.com/v1/")
 
-COLLECTION = "sentinel-s2-l2a-cogs"
+COLLECTION = "sentinel-2-l2a"
+
+NODATA = 0
 
 tms = morecantile.tms.get("WebMercatorQuad")
 
 
 def fetch_composites(
-    tile: morecantile.commons.Tile, start: str, end: str, interval: str = "14D"
+    tile: morecantile.commons.Tile,
+    start: str,
+    end: str,
+    interval: str = "14D",
+    up: int = 0,
 ) -> xarray.DataArray:
     search = catalog.search(
         collections=[COLLECTION],
@@ -46,29 +53,27 @@ def fetch_composites(
 
     items = search.get_all_items()
 
-    print(f"Found {len(items)} items")
-
     stack = stackstac.stack(
         items,
         bounds=tms.xy_bounds(tile),
         snap_bounds=False,
         epsg=tms.crs.to_epsg(),
-        resolution=tms._resolution(tms.matrix(zoom=tile.z)),
+        resolution=tms._resolution(tms.matrix(zoom=tile.z + up)),
         dtype="uint16",
         fill_value=0,
         resampling=Resampling.bilinear,
         assets=[
-            "B02",
-            "B03",
-            "B04",
-            "SCL",
+            "blue",
+            "green",
+            "red",
+            "scl",
         ],
     )
 
     data = stack.compute()
 
     # Cloud mask
-    scl = data.sel(band="SCL").astype("uint8")
+    scl = data.sel(band="scl").astype("uint8")
 
     cloud_mask = scl.isin(CLOUDY_OR_NODATA)
 
@@ -137,6 +142,19 @@ def tile_center(tile: morecantile.commons.Tile) -> Tuple[float]:
     "--interval",
     default="14D",
     help="Time interval to use for compositing imagery. Defaults to 14D. This will be passed to the `resample` function on the time dimension from xarray. See https://docs.xarray.dev/en/stable/generated/xarray.DataArray.resample.html",
+    type=str,
+)
+@click.option(
+    "--up",
+    default=0,
+    type=int,
+    help="Use higher zoom level to determine resolution of output videos. The default resolution is 256x256 pixels. Up works as multiplier. For instance, for up=1, the resolution of the video will be 512x512 pixels, and up=2 it will be 1024x1024 px",
+)
+@click.option("--images", is_flag=True, help="Output each frame as png image as well")
+@click.option(
+    "--keep-mp4",
+    is_flag=True,
+    help="Keep intermediary mp4 files",
 )
 def stac_tile(
     dst: Path,
@@ -148,7 +166,10 @@ def stac_tile(
     width: int,
     height: int,
     interval: str,
-):
+    up: int,
+    images: bool,
+    keep_mp4: bool,
+) -> None:
     if not dst.exists():
         raise ValueError(
             f"Target folder {dst} does not exist, please create it before running this script."
@@ -168,13 +189,13 @@ def stac_tile(
         "name": "Videomap",
         "base_url": "videos/",
         "center": tile_center(orig),
-        "zoom": zoom - 1,
+        "zoom": zoom,
         "frames": {},
         "features": [],
     }
 
     for tile in tiles:
-        composites = fetch_composites(tile, start, end, interval)
+        composites = fetch_composites(tile, start, end, interval, up)
 
         filepath = dst / f"videomap-{tile.z}-{tile.x}-{tile.y}.mp4"
         filepathwebm = dst / f"videomap-{tile.z}-{tile.x}-{tile.y}.webm"
@@ -186,18 +207,33 @@ def stac_tile(
             fps=4,
             frameSize=composites.shape[-2:],
         )
+        print(f"Creating videos with frame size of {composites.shape[-2:]}")
         for img in composites:
+            # Prepare video data
             bgr = img.data[:3].transpose(1, 2, 0)
-            bgr = 255 * bgr / 3000
+            bgr = 255 * bgr / 2000
             bgr = numpy.clip(bgr, 0, 255).astype("uint8")
             out.write(bgr)
+            if images:
+                im = Image.fromarray(
+                    numpy.array((bgr[:, :, 2], bgr[:, :, 1], bgr[:, :, 0])).transpose(
+                        1, 2, 0
+                    )
+                )
+                imgpath = (
+                    dst
+                    / f"videomap-{tile.z}-{tile.x}-{tile.y}-{str(img.time.data)[:10]}.png"
+                )
+                im.save(imgpath)
+
         out.release()
 
         # Convert mp4 to webm
         ffmpeg.input(str(filepath)).output(str(filepathwebm)).run(overwrite_output=True)
 
         # Delete mp4 video
-        filepath.unlink()
+        if not keep_mp4:
+            filepath.unlink()
 
         # Add tms tile feature to videos geojson object
         feat = tms.feature(tile)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "videomap"
+version = "0.1.0"
+authors = [
+  { name="Daniel Wiesmann", email="danielwiesmann@developmentseed.org" },
+]
+description = "Videomaps command line utility"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "opencv-python",
+    "ffmpeg-python",
+    "stackstac",
+    "pystac_client",
+    "morecantile",
+    "click",
+    "pillow",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/developmentseed/videomap.earth"
+"Bug Tracker" = "https://github.com/developmentseed/videomap.earth/issues"
+
+[project.scripts]
+stac2video = "videomap.stac2video:stac_tile"


### PR DESCRIPTION
A bunch of improvements, moving towards closing the python side on this project for now.

- Pip installable
- Made sure docs are readable and up to date
- Added a few more controls to stac2video script
- Added more metadata to the video.geojson @nerik including a `"dates"` field containing a list of dates that went into each frame at the full level (different dates for different tiles, but merged dates into a list per frame for all videos together)